### PR TITLE
add check for secondary DNS

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -39,7 +39,14 @@ function addClient() {
 	echo "[Interface]
 PrivateKey = $CLIENT_PRIV_KEY
 Address = $CLIENT_WG_IPV4/24,$CLIENT_WG_IPV6/64
-DNS = $CLIENT_DNS_1,$CLIENT_DNS_2
+
+# Fix for bug where trailing comma is left if no secondary DNS specified
+if [ -z "$CLIENT_DNS_2" ]
+then
+	DNS = $CLIENT_DNS_1,$CLIENT_DNS_2
+else
+	DNS = $CLIENT_DNS_1
+fi
 
 [Peer]
 PublicKey = $SERVER_PUB_KEY


### PR DESCRIPTION
Added a quick if statement to check for a secondary DNS server. If left with the default or provided with one, uses it. Otherwise, eliminates trailing comma from DNS variable assignment.